### PR TITLE
Make GitHub issues link into a Bootstrap button

### DIFF
--- a/ampcamp/_layouts/global.html
+++ b/ampcamp/_layouts/global.html
@@ -73,7 +73,6 @@
             {{ content }}
         </div> <!-- /container -->
         <div class="bar bottombar">
-          <div><a target="_blank" href="https://github.com/amplab/training/issues">Submit an issue to the Github training docs issue tracker</a></div>
             {% include left-page-nav-button.html %}
             {% include right-page-nav-button.html %}
             <div class="btn-group dropup">
@@ -83,6 +82,12 @@
                 <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu">
                     {% include chapter-list.html %}
                 </ul>
+            </div>
+            <div class="btn-group dropup">
+              <a class="btn btn-large" target="_blank" href="https://github.com/amplab/training/issues">
+                <i class="icon-exclamation-sign"> </i>
+                Submit an issue on GitHub
+              </a>
             </div>
             <div class="site-title">{{ site.title }}</div>
         </div>


### PR DESCRIPTION
I think the footer looks nicer if the GitHub issues link is a Bootstrap button.  What do you think?

![image](https://f.cloud.github.com/assets/50748/1029687/55e06344-0e9d-11e3-8445-92dbd49eb340.png)
