### PR TITLE
Changed scala version for ampcamp4

### DIFF
--- a/streaming/scala/build.sbt
+++ b/streaming/scala/build.sbt
@@ -1,6 +1,6 @@
 name := "Tutorial"
 
-scalaVersion := "2.10"
+scalaVersion := "2.10.3"
 
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-streaming" % "0.9.0-incubating",


### PR DESCRIPTION
In ampcamp4, scala 2.10.3 is installed in amazon ec2 instance. So this scala version should be 2.10.3.
