### PR TITLE
Under Input/Output fixed typo in python example

### DIFF
--- a/ampcamp/tachyon.md
+++ b/ampcamp/tachyon.md
@@ -276,7 +276,7 @@ counts.saveAsTextFile("tachyon://localhost:19998/result");
 </div>
 <div data-lang="python" markdown="1">
 ~~~
-file = spark.textFile("tachyon://localhost:19998/LICENSE")
+file = sc.textFile("tachyon://localhost:19998/LICENSE")
 counts = file.flatMap(lambda line: line.split(" ")) \
              .map(lambda word: (word, 1)) \
              .reduceByKey(lambda a, b: a + b)


### PR DESCRIPTION
Spark Context in python shell is referenced by "spark" instead of "sc"
